### PR TITLE
add homepage field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": false,
   "version": "0.5.0",
   "license": "MIT",
+  "homepage": "https://github.com/Veriphi/veto-ui",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
# Description
I want the github repo to show up as homepage on https://www.npmjs.com/package/@veriphi/veto-ui
I believe this is how you do that... so that it shows up on next publish?